### PR TITLE
replace panic_impl with panic_handler and remove -nostartfiles

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,5 +4,4 @@ target = "thumbv7em-none-eabihf"
 [target.thumbv7em-none-eabihf]
 rustflags = [
 	"-C", "link-arg=-Tlm4f120.ld",
-	"-C", "link-arg=-nostartfiles"
 ]

--- a/src/common/builtins.rs
+++ b/src/common/builtins.rs
@@ -66,7 +66,7 @@ pub extern "C" fn _Unwind_Resume() -> ! {
     board::panic();
 }
 
-#[panic_implementation]
+#[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     board::panic();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(asm)]
 #![feature(core_intrinsics)]
 #![feature(naked_functions)]
-#![feature(panic_implementation)]
 #![no_std]
 #![warn(dead_code)]
 #![deny(missing_docs)]


### PR DESCRIPTION
Required to build on newer versions of Rust. Tested on a TM4C123GXL.